### PR TITLE
based advanced request handler on basic

### DIFF
--- a/solrconfig.xml
+++ b/solrconfig.xml
@@ -327,183 +327,267 @@
   </requestHandler>
 
   <!--  For Advanced Search  -->
-  <requestHandler name="advanced" class="solr.SearchHandler" >
+  <requestHandler name="advanced" class="solr.SearchHandler">
+    <!-- default values for query parameters can be specified, these
+         will be overridden by parameters in the request
+      -->
     <lst name="defaults">
       <str name="defType">lucene</str>
       <str name="echoParams">explicit</str>
-      <str name="sort">score desc, pub_date_sort desc, title_sort asc</str>
+      <int name="rows">10</int>
+
+      <!--<str name="q.alt">*:*</str>-->
       <str name="df">text</str>
-      <str name="q.op">AND</str>
-      <str name="qs">1</str>
+      <str name="mm">2&lt;-1 5&lt;-2 6&lt;90%</str>
 
-      <!-- used for dismax query parser -->
-      <str name="mm">1</str>
-      <str name="ps">3</str>
-      <float name="tie">0.01</float>
+      <!-- this qf and pf are used by default, if not otherwise specified by
+           client. The default blacklight_config will use these for the
+           "keywords" search. See the author_qf/author_pf, title_qf, etc
+           below, which the default blacklight_config will specify for
+           those searches. You may also be interested in:
+           http://wiki.apache.org/solr/LocalParams
+      -->
 
-      <!-- for user query terms in author text box -->
-      <str name="qf_author">
+      <str name="qf">
+        cjk^100001
+        title_txt^100000
+        title_txt_cjk^100000
+        subject_txt_cjk^100000
+        subtitle_txt^50000
+        subtitle_txt_cjk^50000
+        title_addl_txt^5000
+        title_addl_txt_cjk^5000
+        subject_txt^750
+        author_txt^25000
+        author_addl_txt^25000
+        author_txt_cjk^25000
+        author_addl_txt_cjk^25000
+        title_series_txt_cjk^1000
+        pub_place_txt_cjk^1000
+        pub_name_txt_cjk^1000
+        text
+        text_copy_cjk
+      </str>
+      <str name="pf">
+        cjk^100001
+        title_starts_with^1000000
+        title_txt^1000000
+        title_txt_cjk^100000
+        subtitle_txt^500000
+        subtitle_txt_cjk^500000
+        title_addl_txt^50000
+        title_addl_txt_cjk^50000
+        subject_txt^7500
+        subject_txt_cjk^7500
+        author_txt^250000
+        author_txt_cjk^250000
+        author_addl_txt^250000
+        author_addl_txt_cjk^250000
+        text^10
+        text_copy_cjk^10
+        title_series_txt_cjk^1000
+        pub_place_txt_cjk^1000
+        pub_name_txt_cjk^1000
+      </str>
+      <str name="author_qf">
         author_txt^200
         author_addl_txt^50
-        author_t^20
-        author_addl_t
-       <!-- cjk -->
+        <!-- cjk -->
         author_txt_cjk^200
         author_addl_txt_cjk^50
+
       </str>
-      <str name="pf_author">
+      <str name="author_pf">
         author_txt^2000
         author_addl_txt^500
-        author_t^200
-        author_addl_t^10
         <!-- cjk -->
         author_txt_cjk^2000
         author_addl_txt_cjk^500
       </str>
-
-      <!-- for user query terms in title text box -->
-      <str name="qf_title">
+      <str name="title_qf">
         title_txt^50000
         title_txt_cjk^50000
         subtitle_txt^25000
-       subtitle_txt_cjk^25000
+        subtitle_txt_cjk^25000
         title_addl_txt^10000
-       title_addl_txt_cjk^10000
-        title_t^5000
-        subtitle_t^2500
-        title_addl_t^100
-        title_added_entry_txt^50
-        title_added_entry_t^10
-        title_series_txt^5
-       title_series_txt_cjk^5
-        title_series_t
+        title_addl_txt_cjk^10000
+        title_series_txt^5000
+        title_series_txt_cjk^5000
       </str>
-      <str name="pf_title">
+      <str name="title_pf">
+        title_starts_with^1000000
         title_txt^500000
-        title_txt_cjk^50000
         subtitle_txt^250000
-       subtitle_txt_cjk^250000
         title_addl_txt^100000
-       title_addl_txt_cjk^100000
-        title_t^50000
-        subtitle_t^25000
-        title_addl_t^1000
-        title_added_entry_txt^500
-        title_added_entry_t^100
-        title_series_t^50
-        title_series_txt^10
-       title_series_txt_cjk^10
-      </str>
+        title_series_txt^50000
+        <!-- cjk -->
+        title_txt_cjk^500000
+        subtitle_txt_cjk^250000
+        title_addl_txt_cjk^100000
+        title_series_txt_cjk^50000
 
-      <!-- for user query terms in subject text box -->
-      <str name="qf_subject">
-        subject_topic_txt^200
+      </str>
+      <str name="title_start_qf">
+        title_starts_with^10
+      </str>
+      <str name="title_start_pf">
+        title_starts_with^100
+      </str>
+      <str name="subject_qf">
         subject_txt^125
-       subject_txt_cjk^125
-        subject_local_txt^110
-        subject_topic_facet^100
-        subject_t^50
-        subject_addl_txt^10
-        subject_addl_t
+        subject_txt_cjk^125
       </str>
-      <str name="pf_subject">
-        subject_topic_txt^2000
+      <str name="subject_pf">
         subject_txt^1250
-       subject_txt_cjk^1250
+        subject_txt_cjk^1250
+      </str>
+      <str name="subject_local_qf">
+        subject_local_txt^110
+      </str>
+      <str name="subject_local_pf">
         subject_local_txt^1100
-        subject_t^1000
-        subject_topic_facet^500
-        subject_addl_txt^100
-        subject_addl_t^10
       </str>
 
-      <!-- for user query terms in number text box -->
-      <str name="qf_number">isbn_t</str>
-
-      <!-- for user query terms in keyword text box -->
-      <str name="qf_keyword">text</str>
-      <str name="pf_keyword">text^10</str>
+      <int name="ps">3</int>
+      <float name="tie">0.01</float>
 
       <!-- NOT using marc_display because it is large and will slow things down for search results -->
       <str name="fl">
         id,
+        <!-- cjk. Not sure what fields should be here -->
         cjk,
         title_txt_cjk,
         subject_txt_cjk,
+        subtitle_txt_cjk,
+        author_txt_cjk,
+        title_series_txt_cjk,
+        pub_place_txt_cjk,
+        pub_name_txt_cjk,
+        subject_txt_cjk,
+        title_addl_txt_cjk,
+        author_addl_txt_cjk,
+        clio_id_display,
         score,
         author_display,
         author_vern_display,
-        clio_id_display,
+        author_facet,
         format,
-        isbn_t,
+        isbn_display,
         language_facet,
-        lc_callnum_display,
-        location_call_number_id_display,
+        database_restrictions_display,
         material_type_display,
-        pub_date_facet,
-        acq_dt,
+        lc_callnum_display,
+        full_publisher_display,
+        location_call_number_id_display,
+        published_display,
+        published_vern_display,
         title_display,
         title_vern_display,
-        title_series_display,
-        subtitle_display,
-        subtitle_vern_display,
-        oclc_display,
-        lccn_display,
-        database_summary_display,
-        summary_display,
         subject_topic_facet,
         subject_geo_facet,
         subject_era_facet,
         subject_local_facet,
-        database_hilcc_facet,
-        database_resource_type_facet,
-        location_facet,
-        full_publisher_display,
-        location_holdings_id_display,
-        location_display,
-        location_call_number_id_display,
+        subtitle_display,
+        subtitle_vern_display,
         url_fulltext_display,
         url_munged_display,
-        url_suppl_display
-        source_display
+        url_suppl_display,
+        text_copy_cjk
       </str>
 
+      <!--YUL 3/23/17 commented out facet fields copied from cul advanced search for reference-->
       <str name="facet">true</str>
       <str name="facet.mincount">1</str>
       <str name="facet.limit">10</str>
       <str name="facet.field">format</str>
-      <str name="f.format.facet.method">enum</str>
+      <!--<str name="f.format.facet.method">enum</str>-->
       <str name="facet.field">lc_1letter_facet</str>
-      <str name="f.lc_1letter_facet.facet.sort">index</str>
-      <str name="f.lc_1letter_facet.facet.method">enum</str>
-      <str name="facet.field">lc_2letter_facet</str>
+      <!--<str name="f.lc_1letter_facet.facet.sort">index</str>
+      <str name="f.lc_1letter_facet.facet.method">enum</str>-->
+      <!--<str name="facet.field">lc_2letter_facet</str>
       <str name="f.lc_2letter_facet.facet.sort">index</str>
-      <str name="f.lc_2letter_facet.facet.method">enum</str>
+      <str name="f.lc_2letter_facet.facet.method">enum</str>-->
+      <str name="facet.field">lc_alpha_facet</str><!--not in advanced search-->
+      <str name="facet.field">lc_b4cutter_facet</str><!--not in advanced search-->
       <str name="facet.field">language_facet</str>
-      <str name="f.language_facet.facet.method">enum</str>
-      <str name="facet.field">pub_date_sort</str>
+      <!--<str name="f.language_facet.facet.method">enum</str>-->
+      <!--<str name="facet.field">pub_date_sort</str>-->
+      <str name="facet.field">subject_era_facet</str>
+      <str name="facet.field">subject_local_facet</str>
       <str name="facet.field">subject_geo_facet</str>
       <str name="facet.field">subject_topic_facet</str>
-      <str name="facet.field">subject_era_facet</str>
-      <str name="facet.field">subject_form_facet</str>
-      <str name="facet.field">subject_local_facet</str>
+      <!--<str name="facet.field">subject_form_facet</str>
       <str name="facet.field">database_hilcc_facet</str>
       <str name="facet.field">database_resource_type_facet</str>
       <str name="facet.field">location_facet</str>
       <str name="f.location_facet.facet.method">enum</str>
       <str name="facet.field">author_facet</str>
-      <str name="facet.field">source_facet</str>
+      <str name="facet.field">source_facet</str>-->
 
       <str name="spellcheck">true</str>
-      <str name="spellcheck.dictionary">subject</str>
+      <str name="spellcheck.dictionary">default</str>
       <str name="spellcheck.onlyMorePopular">true</str>
       <str name="spellcheck.extendedResults">true</str>
       <str name="spellcheck.collate">false</str>
       <str name="spellcheck.count">5</str>
+
     </lst>
+    <!-- In addition to defaults, "appends" params can be specified
+         to identify values which should be appended to the list of
+         multi-val params from the query (or the existing "defaults").
+      -->
+    <!-- In this example, the param "fq=instock:true" would be appended to
+         any query time fq params the user may specify, as a mechanism for
+         partitioning the index, independent of any user selected filtering
+         that may also be desired (perhaps as a result of faceted searching).
+
+         NOTE: there is *absolutely* nothing a client can do to prevent these
+         "appends" values from being used, so don't use this mechanism
+         unless you are sure you always want it.
+      -->
+    <!--
+       <lst name="appends">
+         <str name="fq">inStock:true</str>
+       </lst>
+      -->
+    <!-- "invariants" are a way of letting the Solr maintainer lock down
+         the options available to Solr clients.  Any params values
+         specified here are used regardless of what values may be specified
+         in either the query, the "defaults", or the "appends" params.
+
+         In this example, the facet.field and facet.query params would
+         be fixed, limiting the facets clients can use.  Faceting is
+         not turned on by default - but if the client does specify
+         facet=true in the request, these are the only facets they
+         will be able to see counts for; regardless of what other
+         facet.field or facet.query params they may specify.
+
+         NOTE: there is *absolutely* nothing a client can do to prevent these
+         "invariants" values from being used, so don't use this mechanism
+         unless you are sure you always want it.
+      -->
+    <!--
+       <lst name="invariants">
+         <str name="facet.field">cat</str>
+         <str name="facet.field">manu_exact</str>
+         <str name="facet.query">price:[* TO 500]</str>
+         <str name="facet.query">price:[500 TO *]</str>
+       </lst>
+      -->
+    <!-- If the default list of SearchComponents is not desired, that
+         list can either be overridden completely, or components can be
+         prepended or appended to the default list.  (see below)
+      -->
+    <!--
+       <arr name="components">
+         <str>nameOfCustomComponent1</str>
+         <str>nameOfCustomComponent2</str>
+       </arr>
+      -->
     <arr name="last-components">
       <str>spellcheck</str>
     </arr>
+
   </requestHandler>
 
 <!-- Spell Check


### PR DESCRIPTION
for review by Kalee Sprague and Osman Din

1) bases advanced search request handler on basic search request handler
2) maintains the differences between basic and advanced as inherited from columbia in comments (see facet and spellcheck code paragraphs within advanced request handler)

to test:
cjk should continue to work
equivalent basic search/advanced search should have same result

also to determine:
whether the facet and spellcheck inherited from columbia (see commented out parts) should apply 